### PR TITLE
Make Context Aware

### DIFF
--- a/js/erlpack.cc
+++ b/js/erlpack.cc
@@ -46,4 +46,6 @@ NAN_MODULE_INIT(Init) {
     // target->Set(Nan::New("unpack").ToLocalChecked(), Nan::New<FunctionTemplate>(Unpack)->GetFunction());
 }
 
-NODE_MODULE(erlpack, Init);
+NODE_MODULE_INIT() {
+ Init(exports);   
+}


### PR DESCRIPTION
Module previously was not context aware, causing it to import fail in NodeJS worker threads

nodejs/node#21783