### PR TITLE
Bump NPM package version to 0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "main": "./js/index.js",
   "types": "./js/index.d.ts",
   "name": "erlpack",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Erlpack is a fast encoder and decoder for the Erlang Term Format (version 131) for JavaScript",
   "scripts": {
     "test": "jest"


### PR DESCRIPTION
To get the Node 16 updates onto NPM, I updated the version to 0.1.4 (As it does not break usage with Node 12 I think incrementing patch is fine): https://www.npmjs.com/package/erlpack

To keep the consistency the version should be updated here too.