### PR TITLE
Update nan package to fix build issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "bindings": "^1.5.0",
-    "nan": "^2.15.0"
+    "nan": "^2.17.0"
   },
   "gypfile": true,
   "devDependencies": {


### PR DESCRIPTION
The postbuild script to rebuild those packages when installing discord.js (on Node 19 for me) with:

```
../../nan/nan_callbacks.h:55:23: error: ‘AccessorSignature’ is not a member of ‘v8’
   55 | typedef v8::Local<v8::AccessorSignature> Sig;
      |                       ^~~~~~~~~~~~~~~~~
../../nan/nan_callbacks.h:55:40: error: template argument 1 is invalid
   55 | typedef v8::Local<v8::AccessorSignature> Sig;
      | 
```

Changelog: https://github.com/nodejs/nan/compare/v2.16.0...v2.17.0

`yarn why nan` showed that those packages prefer the older versions, simply adding to my package.json
```json
"resolutions": {
    "nan": "2.17.0"
},
```

fixes the issue. Not sure if there's anything better I could do

Resolves #57